### PR TITLE
Support MySQL 8.4, deprecate MySQL 8.0 and MariaDB 10.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,21 @@ PLATFORMS=linux/arm64/v8,linux/amd64
 
 # Defaults:
 MARIADB_VERSION=10.7
-MYSQL_VERSION=8.0
+MYSQL_VERSION=8.4
 
 #BUILDX_OPTIONS=--push
 DOCKER_CACHE=--cache-from "type=local,src=.buildx-cache" --cache-to "type=local,dest=.buildx-cache"
 
-build:
+build-mariadb:
 	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \
 		--platform $(PLATFORMS) \
 		-f Dockerfile.mariadb \
 		--build-arg MARIADB_VERSION=$(MARIADB_VERSION) --tag croneu/phpapp-db:mariadb-$(MARIADB_VERSION) .
+
+build-mysql:
 	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \
 		--platform $(PLATFORMS) \
 		-f Dockerfile.mysql \
 		--build-arg MYSQL_VERSION=$(MYSQL_VERSION) --tag croneu/phpapp-db:mysql-$(MYSQL_VERSION) .
+
+build: build-mysql

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ This is the MySQL database container, with images for **amd64** and **arm64**
 
 ## Tags available
 
-* `croneu/phpapp-db:mariadb-10.7`
-* `croneu/phpapp-db:mysql-8.0`
+* `croneu/phpapp-db:mysql-8.4`
+* `croneu/phpapp-db:mariadb-10.7` - no longer maintained
+* `croneu/phpapp-db:mysql-8.0` - no longer maintained
 
 This is just a pre-configured alternative to the upstream official images (**MariaDB** or **MySQL**).
 This  allows us to use it straight on for TYPO3 projects without having to include any further
@@ -24,6 +25,22 @@ configuration or do any performance tuning.
 See upstream:
 * https://hub.docker.com/_/mariadb
 * https://hub.docker.com/_/mysql
+
+Example `docker-compose.yaml` for MySQL 8.0:
+
+```
+  mysql:
+    image: croneu/phpapp-db:mysql-8.4
+    ports:
+      - 13306:3306
+    volumes:
+      - mysql:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASS}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASS}
+```
 
 Example `docker-compose.yaml` for MariaDB:
 
@@ -39,22 +56,6 @@ Example `docker-compose.yaml` for MariaDB:
       MARIADB_DATABASE: ${DB_NAME}
       MARIADB_USER: ${DB_USER}
       MARIADB_PASSWORD: ${DB_PASS}
-```
-
-Example `docker-compose.yaml` for MySQL 8.0:
-
-```
-  mysql:
-    image: croneu/phpapp-db:mysql-8.0
-    ports:
-      - 13306:3306
-    volumes:
-      - mysql:/var/lib/mysql
-    environment:
-      MYSQL_ROOT_PASSWORD: ${DB_PASS}
-      MYSQL_DATABASE: ${DB_NAME}
-      MYSQL_USER: ${DB_USER}
-      MYSQL_PASSWORD: ${DB_PASS}
 ```
 
 ----


### PR DESCRIPTION
New:
* `croneu/phpapp-db:mysql-8.4`

Deprecated (no new images will be created, but old images remain in repository):
* `croneu/phpapp-db:mariadb-10.7`
* `croneu/phpapp-db:mysql-8.0`
