### PR TITLE
Build MariaDB 10.11 and 11.8

### DIFF
--- a/Dockerfile.mariadb
+++ b/Dockerfile.mariadb
@@ -1,9 +1,10 @@
 # See https://hub.docker.com/_/mariadb/
 
-ARG MARIADB_VERSION=10.7
+ARG MARIADB_RELEASE=10.11
 
-FROM mariadb:${MARIADB_VERSION}
+FROM mariadb:${MARIADB_RELEASE}
+ARG MARIADB_RELEASE
 
-ADD mariadb.cnf /etc/mysql/conf.d/z99-docker.cnf
+ADD mariadb-${MARIADB_RELEASE}.cnf /etc/mysql/conf.d/z99-docker.cnf
 RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
     && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf

--- a/Dockerfile.mysql
+++ b/Dockerfile.mysql
@@ -1,9 +1,10 @@
 # See https://hub.docker.com/_/mysql/
 
-ARG MYSQL_VERSION=8.0
+ARG MYSQL_RELEASE=8.4
 
-FROM mysql:${MYSQL_VERSION}
+FROM mysql:${MYSQL_RELEASE}
+ARG MYSQL_RELEASE
 
-ADD mysql.cnf /etc/mysql/conf.d/z99-docker.cnf
+ADD mysql-${MYSQL_RELEASE}.cnf /etc/mysql/conf.d/z99-docker.cnf
 RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
     && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MARIADB_RELEASE=11.8
 MARIADB_RELEASE_LEGACY=10.11
 
 # MySQL:
-MYSQL_VERSION=8.4
+MYSQL_RELEASE=8.4
 
 #BUILDX_OPTIONS=--push
 DOCKER_CACHE=--cache-from "type=local,src=.buildx-cache" --cache-to "type=local,dest=.buildx-cache"
@@ -28,6 +28,6 @@ build-mysql:
 	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \
 		--platform $(PLATFORMS) \
 		-f Dockerfile.mysql \
-		--build-arg MYSQL_VERSION=$(MYSQL_VERSION) --tag croneu/phpapp-db:mysql-$(MYSQL_VERSION) .
+		--build-arg MYSQL_RELEASE=$(MYSQL_RELEASE) --tag croneu/phpapp-db:mysql-$(MYSQL_RELEASE) .
 
 build: build-mysql build-mariadb build-mariadb-legacy

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 
 PLATFORMS=linux/arm64/v8,linux/amd64
 
-# Defaults:
-MARIADB_VERSION=10.7
+# MariaDB, see https://endoflife.date/mariadb
+# we only build "LTS" versions:
+MARIADB_RELEASE=11.8
+MARIADB_RELEASE_LEGACY=10.11
+
+# MySQL:
 MYSQL_VERSION=8.4
 
 #BUILDX_OPTIONS=--push
@@ -12,7 +16,13 @@ build-mariadb:
 	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \
 		--platform $(PLATFORMS) \
 		-f Dockerfile.mariadb \
-		--build-arg MARIADB_VERSION=$(MARIADB_VERSION) --tag croneu/phpapp-db:mariadb-$(MARIADB_VERSION) .
+		--build-arg MARIADB_RELEASE=$(MARIADB_RELEASE) --tag croneu/phpapp-db:mariadb-$(MARIADB_RELEASE) .
+
+build-mariadb-legacy:
+	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \
+		--platform $(PLATFORMS) \
+		-f Dockerfile.mariadb \
+		--build-arg MARIADB_RELEASE=$(MARIADB_RELEASE_LEGACY) --tag croneu/phpapp-db:mariadb-$(MARIADB_RELEASE_LEGACY) .
 
 build-mysql:
 	docker buildx build $(DOCKER_CACHE) $(BUILDX_OPTIONS) \
@@ -20,4 +30,4 @@ build-mysql:
 		-f Dockerfile.mysql \
 		--build-arg MYSQL_VERSION=$(MYSQL_VERSION) --tag croneu/phpapp-db:mysql-$(MYSQL_VERSION) .
 
-build: build-mysql
+build: build-mysql build-mariadb build-mariadb-legacy

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ This is the MySQL database container, with images for **amd64** and **arm64**
 ## Tags available
 
 * `croneu/phpapp-db:mysql-8.4`
+* `croneu/phpapp-db:mariadb-11.8`
+* `croneu/phpapp-db:mariadb-10.11`
 * `croneu/phpapp-db:mariadb-10.7` - no longer maintained
 * `croneu/phpapp-db:mysql-8.0` - no longer maintained
 
 This is just a pre-configured alternative to the upstream official images (**MariaDB** or **MySQL**).
-This  allows us to use it straight on for TYPO3 projects without having to include any further
+This allows us to use it straight on for TYPO3 projects without having to include any further
 configuration or do any performance tuning.
 
 ## Settings
@@ -26,7 +28,7 @@ See upstream:
 * https://hub.docker.com/_/mariadb
 * https://hub.docker.com/_/mysql
 
-Example `docker-compose.yaml` for MySQL 8.0:
+Example `docker-compose.yaml` for MySQL 8.4:
 
 ```
   mysql:
@@ -46,7 +48,7 @@ Example `docker-compose.yaml` for MariaDB:
 
 ```
   mysql:
-    image: croneu/phpapp-db:mariadb-10.7
+    image: croneu/phpapp-db:mariadb-10.11
     ports:
       - 13306:3306
     volumes:

--- a/mariadb-10.11.cnf
+++ b/mariadb-10.11.cnf
@@ -17,7 +17,7 @@ key_buffer_size = 200M
 query_cache_size = 100M
 
 # default is 128M
-innodb_buffer_pool_size = 250M
+innodb_buffer_pool_size = 256M
 
 # default is 16M
 tmp_table_size = 200M

--- a/mariadb-11.8.cnf
+++ b/mariadb-11.8.cnf
@@ -1,0 +1,56 @@
+[mysqld]
+
+# Defaults noted here are from MariaDB 10.7 (official docker image)
+
+#################################################
+## Charset (default is utfmb4)
+
+skip-character-set-client-handshake
+
+#################################################
+## Buffers
+
+# default is 128M
+innodb_buffer_pool_size = 256M
+
+# default is 16M
+tmp_table_size = 64M
+
+# default is 16M
+max_heap_table_size = 64M
+
+# default is 256k
+join_buffer_size = 4M
+
+#################################################
+## Misc
+
+# default is 1
+innodb_flush_log_at_trx_commit = 2
+
+# default is 1
+innodb_file_per_table = 1
+
+#################################################
+## Query log
+
+# default is OFF
+slow_query_log = 1
+
+# default is a random filename
+slow_query_log_file = /dev/stderr
+
+# default is 10
+long_query_time = 1
+
+#################################################
+## Connections
+
+# default is 100
+max_connections = 20
+
+#################################################
+## TYPO3 compatibility
+
+# default is STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+sql_mode = "NO_ENGINE_SUBSTITUTION"

--- a/mysql-8.4.cnf
+++ b/mysql-8.4.cnf
@@ -1,12 +1,12 @@
 [mysqld]
 
-# Defaults noted here are from MySQL 8.0 (official docker image)
+# Defaults noted here are from MySQL 8.4 (official docker image)
 
 #################################################
 ## Buffers
 
 # default is 8M
-key_buffer_size = 128M
+key_buffer_size = 32M
 
 # default is 128M
 innodb_buffer_pool_size = 512M
@@ -15,13 +15,13 @@ innodb_buffer_pool_size = 512M
 innodb_redo_log_capacity = 512M
 
 # default is 16M
-innodb_log_buffer_size = 128M
+innodb_log_buffer_size = 64M
 
 # default is 16M
-tmp_table_size = 128M
+tmp_table_size = 64M
 
 # default is 16M
-max_heap_table_size = 128M
+max_heap_table_size = 64M
 
 # default is 256k
 join_buffer_size = 4M
@@ -39,10 +39,13 @@ read_rnd_buffer_size = 1M
 ## Misc
 
 # default is 1
-innodb_flush_log_at_trx_commit = 0
+innodb_flush_log_at_trx_commit = 2
 
 # default is fsync
-innodb_flush_method = O_DSYNC
+innodb_flush_method = O_DIRECT
+
+# Ensure InnoDB is used by default
+default_storage_engine = InnoDB
 
 #################################################
 ## Connections
@@ -54,4 +57,4 @@ max_connections = 20
 ## TYPO3 compatibility
 
 # default is ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
-sql_mode = ""
+sql_mode = "NO_ENGINE_SUBSTITUTION"


### PR DESCRIPTION
### MariaDB

* See https://endoflife.date/mariadb - we stick to the LTS versions
  * MariaDB 10.11
  * MariaDB 11.8
* Adapted settings (`.cnf`) per version

### MySQL

* MySQL 8.4
* Adapted settings (`.cnf`) - i.e. removed query_cache, tweaked some settings