### PR TITLE
Fix slow-log in mariadb

### DIFF
--- a/Dockerfile.mariadb
+++ b/Dockerfile.mariadb
@@ -8,3 +8,5 @@ ARG MARIADB_RELEASE
 ADD mariadb-${MARIADB_RELEASE}.cnf /etc/mysql/conf.d/z99-docker.cnf
 RUN chown mysql:mysql /etc/mysql/conf.d/z99-docker.cnf \
     && chmod 0644 /etc/mysql/conf.d/z99-docker.cnf
+
+RUN set -ex && mkdir -p /var/log/mysql && chown mysql:mysql -R /var/log/mysql

--- a/mariadb-10.11.cnf
+++ b/mariadb-10.11.cnf
@@ -64,11 +64,11 @@ query_cache_type = 1
 # default is OFF
 slow_query_log = 1
 
-# default is a random filename
-slow_query_log_file = /dev/stderr
+# default is in HOME of mysql (var/lib/mysql)
+slow_query_log_file=/var/log/mysql/slow.log
 
-# default is 10
-long_query_time = 1
+# default is 10, in seconds
+long_query_time = 1.0
 
 #################################################
 ## Connections

--- a/mariadb-11.8.cnf
+++ b/mariadb-11.8.cnf
@@ -37,11 +37,11 @@ innodb_file_per_table = 1
 # default is OFF
 slow_query_log = 1
 
-# default is a random filename
-slow_query_log_file = /dev/stderr
+# default is in HOME of mysql (var/lib/mysql)
+slow_query_log_file=/var/log/mysql/slow.log
 
-# default is 10
-long_query_time = 1
+# default is 10, in seconds
+long_query_time = 1.0
 
 #################################################
 ## Connections


### PR DESCRIPTION
If you want to see these, simply output the /var/log/mysql/* file